### PR TITLE
fix: open current directory when select_current_file = false

### DIFF
--- a/lua/ranger-nvim.lua
+++ b/lua/ranger-nvim.lua
@@ -107,7 +107,7 @@ local function build_ranger_cmd(select_current_file)
 	if vim.fn.expand("%") then
 		selected_file = "'" .. vim.fn.expand("%") .. "'"
 	end
-	local selectfile_flag = select_current_file and " --selectfile=" .. selected_file
+	local selectfile_flag = select_current_file and " --selectfile=" .. selected_file or ""
 	return string.format(
 		"ranger --choosefiles=%s %s %s",
 		SELECTED_FILEPATH,


### PR DESCRIPTION
The condition changed by this PR would inject `false` in the ranger command, which makes ranger try to open the `false` path which doesn't exist.

By adding `or ""` we can default to injecting an empty string if select_current_file is `false`, which fixes the issue.