### PR TITLE
[FEATURE] Close buffers for files deleted in ranger

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ do not invoke `ranger_nvim.setup()` `ranger.nvim` will use the default values.
 | `enable_cmds` | `boolean` | `false` | Set vim commands, see [commands](#commands). |
 | `keybinds` | `Keybind = table<string, OPEN_MODE>` | See [ranger keybindings](#ranger-keybindings). | Key bindings set in `ranger` to control how files are opened in neovim. See [ranger keybindings](#ranger-keybindings). |
 | `replace_netrw` | `boolean` | `false` | Replace `netrw` with `ranger` when neovim is launched with a directory argument. |
+| `close_deleted_files` | `boolean` | `false` | Attempt to close buffers for files that were deleted with `ranger`. |
 | `ui` | `UI` | See [UI Configuration](#configuration---ui). | Settings for ranger window. |
 
 See below code snippet for example configuring `ranger.nvim` with the default
@@ -52,6 +53,7 @@ local ranger_nvim = require("ranger-nvim")
 ranger_nvim.setup({
   enable_cmds = false,
   replace_netrw = false,
+    close_deleted_files = false,
   keybinds = {
     ["ov"] = ranger_nvim.OPEN_MODE.vsplit,
     ["oh"] = ranger_nvim.OPEN_MODE.split,

--- a/lua/ranger-nvim.lua
+++ b/lua/ranger-nvim.lua
@@ -17,6 +17,7 @@ M.OPEN_MODE = {
 ---@class Options
 ---@field enable_cmds boolean set commands
 ---@field replace_netrw boolean
+---@field close_deleted_files boolean
 ---@field keybinds Keybinds
 ---@field ui UI
 
@@ -31,6 +32,7 @@ M.OPEN_MODE = {
 local opts = {
 	enable_cmds = false,
 	replace_netrw = false,
+    close_deleted_files = false,
 	keybinds = {
 		["ov"] = M.OPEN_MODE.vsplit,
 		["oh"] = M.OPEN_MODE.split,
@@ -222,7 +224,10 @@ function M.open(select_current_file)
 	clean_up()
 
 	-- Store buffers that are open (and not empty) prior to running ranger
-	local buffers_for_existing_files = get_buffers_for_existing_files()
+	local buffers_for_existing_files
+    if opts.close_deleted_files then
+        buffers_for_existing_files = get_buffers_for_existing_files()
+    end
 
 	local cmd = build_ranger_cmd(select_current_file)
 	local last_win = vim.api.nvim_get_current_win()
@@ -235,10 +240,13 @@ function M.open(select_current_file)
 				open_files(SELECTED_FILEPATH, get_open_func())
 			end
 			clean_up()
+
 			-- Close any buffers that were previously pointing to existing files, but don't
 			-- after running ranger. This should close any buffers for files which were
 			-- deleted using ranger.
-			close_empty_buffers(buffers_for_existing_files)
+            if opts.close_deleted_files then
+                close_empty_buffers(buffers_for_existing_files)
+            end
 		end,
 	})
 	vim.cmd.startinsert()

--- a/lua/ranger-nvim.lua
+++ b/lua/ranger-nvim.lua
@@ -32,7 +32,7 @@ M.OPEN_MODE = {
 local opts = {
 	enable_cmds = false,
 	replace_netrw = false,
-    close_deleted_files = false,
+	close_deleted_files = false,
 	keybinds = {
 		["ov"] = M.OPEN_MODE.vsplit,
 		["oh"] = M.OPEN_MODE.split,
@@ -225,9 +225,9 @@ function M.open(select_current_file)
 
 	-- Store buffers that are open (and not empty) prior to running ranger
 	local buffers_for_existing_files
-    if opts.close_deleted_files then
-        buffers_for_existing_files = get_buffers_for_existing_files()
-    end
+	if opts.close_deleted_files then
+		buffers_for_existing_files = get_buffers_for_existing_files()
+	end
 
 	local cmd = build_ranger_cmd(select_current_file)
 	local last_win = vim.api.nvim_get_current_win()
@@ -244,9 +244,9 @@ function M.open(select_current_file)
 			-- Close any buffers that were previously pointing to existing files, but don't
 			-- after running ranger. This should close any buffers for files which were
 			-- deleted using ranger.
-            if opts.close_deleted_files then
-                close_empty_buffers(buffers_for_existing_files)
-            end
+			if opts.close_deleted_files then
+				close_empty_buffers(buffers_for_existing_files)
+			end
 		end,
 	})
 	vim.cmd.startinsert()


### PR DESCRIPTION
In relation to #11 

Finally took the time to make a serious attempt at this. Seems to work from my testing but let me know what you think when you have the time.

Unfortunately there's nothing convenient from `ranger` like that `choosefiles` flag which would list deleted files so I took a different approach. Instead I'm storing the listed buffers that point to existing files before opening ranger, then going through that list afterwards and closing buffers for files which no longer exist.