### PR TITLE
Fix: only ranger window NormalFloat hi is set

### DIFF
--- a/lua/ranger-nvim.lua
+++ b/lua/ranger-nvim.lua
@@ -123,7 +123,7 @@ local function open_win()
 	local win_width = math.ceil(vim.o.columns * opts.ui.width)
 	local row = math.ceil((vim.o.lines - win_height) * opts.ui.y - 1)
 	local col = math.ceil((vim.o.columns - win_width) * opts.ui.x)
-	vim.api.nvim_open_win(buf, true, {
+	local win = vim.api.nvim_open_win(buf, true, {
 		relative = "editor",
 		width = win_width,
 		height = win_height,
@@ -132,7 +132,7 @@ local function open_win()
 		col = col,
 		style = "minimal",
 	})
-	vim.api.nvim_set_hl(0, "NormalFloat", { bg = "" })
+	vim.api.nvim_win_set_option(win, "winhl", "NormalFloat:Normal")
 end
 
 ---Clean up temporary files used to communicate between ranger and the plugin.


### PR DESCRIPTION
Fixes a bug where the `NormalFloat` highlight is cleared everywhere after ranger is opened. Now `NormalFloat` is changed only in the ranger window.